### PR TITLE
fix: change ',' to ' and ' in the Repository update method

### DIFF
--- a/modules/database/Repository.php
+++ b/modules/database/Repository.php
@@ -332,7 +332,7 @@ abstract class Repository
             );
         $condition =
             implode(
-                ',',
+                ' and ',
                 array_map(
                     fn ($name) => "$name = :" . $this->aliases[$name],
                     array_keys($conditions)


### PR DESCRIPTION
# What?

Fixed the update method in the Repository class.

# Why?

The query fails if the id is composite.

# How?

Changed the separator from ',' to ' and ' in the update query.